### PR TITLE
💄 Animations

### DIFF
--- a/app/main.tsx
+++ b/app/main.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './components';
-import '../src/styles/main.css';
+import '../src/styles.css';
 import './styles/base.css';
 
 createRoot(document.getElementById('root') as Element).render(

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "start": "cd app && parcel",
+    "start": "cd app && npm run start",
     "watch": "parcel watch",
     "build": "parcel build",
     "lint": "eslint --report-unused-disable-directives --max-warnings 0",

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -9,6 +9,7 @@ import { Position } from 'types';
 interface ContextMenuProps {
   triggerId: string;
   children: ReactNode;
+  animateExit?: boolean;
 }
 
 interface ContextMenuState {
@@ -19,7 +20,7 @@ interface ContextMenuState {
 
 const HIDE_ON_EVENTS: (keyof GlobalEventHandlersEventMap)[] = ['click', 'resize', 'scroll', 'contextmenu'];
 
-const ContextMenu = ({ triggerId, children }: ContextMenuProps) => {
+const ContextMenu = ({ triggerId, children, animateExit = true }: ContextMenuProps) => {
   const [state, setState] = useState<ContextMenuState>({
     active: false,
     leaving: false,
@@ -48,10 +49,18 @@ const ContextMenu = ({ triggerId, children }: ContextMenuProps) => {
   );
 
   const hide = useCallback(() => {
-    setState((prev) => ({
-      ...prev,
-      leaving: true,
-    }));
+    if (animateExit) {
+      setState((prev) => ({
+        ...prev,
+        leaving: true,
+      }));
+    } else {
+      setState((prev) => ({
+        ...prev,
+        active: false,
+      }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleAnimationEnd = useCallback(() => {

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -104,7 +104,7 @@ const ContextMenu = ({ triggerId, children, animateExit = true }: ContextMenuPro
   if (!state.active) return null;
 
   const classNames = cx('react-context-menu', {
-    'react-context-menu__exit': state.leaving,
+    'react-context-menu--exit': state.leaving,
   });
 
   return (

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -119,7 +119,7 @@ const ContextMenu = ({ triggerId, children, animateExit = true }: ContextMenuPro
       onAnimationEnd={handleAnimationEnd}
       tabIndex={-1}
     >
-      {cloneChildren(children)}
+      {cloneChildren(children, { hide })}
     </div>
   );
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,7 +28,7 @@
   }
 }
 
-.react-context-menu__exit {
+.react-context-menu--exit {
   animation: react-context-menu-exit 150ms ease-out forwards;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,6 +19,19 @@
   --react-context-menu-border-radius-outer: 6px;
 }
 
+@keyframes react-context-menu-exit {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.react-context-menu__exit {
+  animation: react-context-menu-exit 150ms ease-out forwards;
+}
+
 .react-context-menu {
   position: fixed;
   z-index: var(--react-context-menu-z-index);

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,6 +6,7 @@
   --react-context-menu-background-color: #f2f2f2;
   --react-context-menu-border-color: #cccccc;
 
+  --react-context-menu-item-color: #2c2c2c;
   --react-context-menu-item-hover-color: #ffffff;
   --react-context-menu-item-hover-disabled-color: #999999;
   --react-context-menu-item-hover-background-color: #4095da;
@@ -19,6 +20,8 @@
   --react-context-menu-border-radius-outer: 6px;
 }
 
+/* Animations */
+
 @keyframes react-context-menu-exit {
   0% {
     opacity: 1;
@@ -31,6 +34,27 @@
 .react-context-menu--exit {
   animation: react-context-menu-exit 150ms ease-out forwards;
 }
+
+@keyframes react-context-menu__item-clicked {
+  0% {
+    color: var(--react-context-menu-item-hover-color);
+    background-color: var(--react-context-menu-item-hover-background-color);
+  }
+  50% {
+    color: var(--react-context-menu-item-color);
+    background-color: transparent;
+  }
+  100% {
+    color: var(--react-context-menu-item-hover-color);
+    background-color: var(--react-context-menu-item-hover-background-color);
+  }
+}
+
+.react-context-menu__item--clicked {
+  animation: react-context-menu__item-clicked 100ms ease-out forwards;
+}
+
+/* Component styles */
 
 .react-context-menu {
   position: fixed;
@@ -56,6 +80,7 @@
 }
 
 .react-context-menu__item {
+  color: var(--react-context-menu-item-color);
   padding: var(--react-context-menu-padding-sm) var(--react-context-menu-padding-md);
 
   line-height: 1;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import { Children, cloneElement, ReactElement, ReactNode } from 'react';
+
+import { MenuItemExternalProps } from 'components/MenuItem';
 import { Position } from 'types';
 
 export const getCursorPosition = (e: MouseEvent): Position => {
@@ -24,8 +26,8 @@ export const validateWindowPosition = (position: Position, element: HTMLDivEleme
   return { x, y };
 };
 
-export const cloneChildren = (children: ReactNode) => {
+export const cloneChildren = (children: ReactNode, props: MenuItemExternalProps) => {
   const filteredItems = Children.toArray(children).filter(Boolean);
 
-  return filteredItems.map((item) => cloneElement(item as ReactElement<any>));
+  return filteredItems.map((item) => cloneElement(item as ReactElement<any>, props));
 };


### PR DESCRIPTION
## 🤖 Summary
This pull request includes several changes to enhance the functionality and styling of the context menu component. The most significant updates involve the addition of animations for menu exit and item click events, as well as the introduction of new props and states to manage these animations.

### Enhancements to Context Menu Component:

* [`src/components/ContextMenu.tsx`](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR2): Added `animateExit` prop and `leaving` state to handle exit animations. Updated the `hide` method to trigger the exit animation if `animateExit` is true. Included `onAnimationEnd` handler to reset states after animation. [[1]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR2) [[2]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR12-R26) [[3]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeL38-R77) [[4]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR106-R122)
* [`src/components/MenuItem.tsx`](diffhunk://#diff-9db0c2baf85f38b9a238d03f1089a686039ab6c6b94ef412bda920293909b7a4L1-R1): Introduced `MenuItemExternalProps` and `MenuItemState` interfaces to manage click animations. Added `onAnimationEnd` handler to hide the menu and trigger the `onClick` event after animation. [[1]](diffhunk://#diff-9db0c2baf85f38b9a238d03f1089a686039ab6c6b94ef412bda920293909b7a4L1-R1) [[2]](diffhunk://#diff-9db0c2baf85f38b9a238d03f1089a686039ab6c6b94ef412bda920293909b7a4L11-R61)

### Styling Updates:

* [`src/styles.css`](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3R9): Added keyframe animations for context menu exit and menu item click events. Updated styles to apply these animations. [[1]](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3R9) [[2]](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3R23-R58) [[3]](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3R83)

### Utility Function Changes:

* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R2-R3): Modified `cloneChildren` function to accept and pass `MenuItemExternalProps` to cloned elements. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R2-R3) [[2]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L27-R32)

### Other Changes:

* [`app/main.tsx`](diffhunk://#diff-bed7e900ff9ef02923fd06ebc653704ec90d5ed44d4b67ff150feb0f09bca274L5-R5): Updated the import path for the main CSS file.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11): Changed the `start` script to use `npm run start` instead of `parcel`.